### PR TITLE
simplify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A X(Formally known as Twitter) API wrapper library for Nim. Inspired by [Tweepy](https://www.tweepy.org/) and [twitter.nim](https://github.com/snus-kin/twitter.nim).
 
-Be aware I only free-tier API access to the X API so I will only develop for those endpoints.
+Be aware I only have free-tier API access to the X API so I will only develop for those endpoints.
 
 This uses OAuth 1.0a.
 
@@ -14,9 +14,7 @@ This uses OAuth 1.0a.
 ## Install
 
 ```Bash
-git clone https://github.com/aspiring-aster/twim.git
-cd twim
-nimble install
+nimble install twim
 ```
 
 ## Example
@@ -27,19 +25,19 @@ import twim
 when isMainModule:
 
   # This is API Key
-  const CONSUMER_KEY: string = "CONSUMERKEY"
+  const CONSUMER_KEY = "CONSUMERKEY"
 
   # This is the API secret key
-  const CONSUMER_SECRET: string = "CONSUMERSECRET"
+  const CONSUMER_SECRET = "CONSUMERSECRET"
 
   # This is the Authentication Access Token
-  const ACCESS_TOKEN: string = "ACCESSTOKEN"
+  const ACCESS_TOKEN = "ACCESSTOKEN"
 
   # This is the Authentication Access Secret
-  const TOKEN_SECRET: string = "TOKENSECRET"
+  const TOKEN_SECRET = "TOKENSECRET"
 
-  const xCli: XAPI = newXAPI(CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, TOKEN_SECRET)
-  let res: string = xCli.PostTextTweet("Hello from twim!")
+  const xCli = newXAPI(CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, TOKEN_SECRET)
+  let res = xCli.PostTextTweet("Hello from twim!")
   echo res
 ```
 


### PR DESCRIPTION
fixed typo

Consider not specifying the type for let, const and var, as it is inferred by the compiler. It's not wrong your way, people just seem to be more used to this.

(Could be changed in the code as well)